### PR TITLE
Improve error handling

### DIFF
--- a/config/Conexion.php
+++ b/config/Conexion.php
@@ -1,5 +1,6 @@
 <?php 
 require_once "global.php";
+require_once "Utilidades.php";
 
 $conexion = new mysqli(DB_HOST, DB_USERNAME, DB_PASSWORD, DB_NAME);
 
@@ -20,7 +21,7 @@ if (!function_exists('ejecutarConsulta')) {
         // Preparar la consulta
         $stmt = $conexion->prepare($sql);
         if ($stmt === false) {
-            echo "Error en la preparación de la consulta: " . $conexion->error;
+            logError("Error en la preparación de la consulta: " . $conexion->error . " - SQL: $sql");
             return false;
         }
         
@@ -38,7 +39,7 @@ if (!function_exists('ejecutarConsulta')) {
             }
             return true; // Para `UPDATE`, `DELETE` o `INSERT`, solo devolver éxito
         } else {
-            echo "Error en la consulta: " . $stmt->error;
+            logError("Error en la consulta: " . $stmt->error . " - SQL: $sql");
             return false;
         }
     }
@@ -49,7 +50,7 @@ if (!function_exists('ejecutarConsulta')) {
     // Prepara la consulta
     $stmt = $conexion->prepare($sql);
     if ($stmt === false) {
-        error_log("Error en la preparación de la consulta: " . $conexion->error);
+        logError("Error en la preparación de la consulta: " . $conexion->error . " - SQL: $sql");
         return null;
     }
 
@@ -67,21 +68,21 @@ if (!function_exists('ejecutarConsulta')) {
             }
         }
         if (!$stmt->bind_param($types, ...$params)) {
-            error_log("Error en bind_param: " . $stmt->error);
+            logError("Error en bind_param: " . $stmt->error . " - SQL: $sql");
             return null;
         }
     }
 
     // Ejecuta la consulta
     if (!$stmt->execute()) {
-        error_log("Error en la ejecución de la consulta: " . $stmt->error);
+        logError("Error en la ejecución de la consulta: " . $stmt->error . " - SQL: $sql");
         return null;
     }
 
     // Obtén el resultado
     $resultado = $stmt->get_result();
     if ($resultado === false) {
-        error_log("Error al obtener el resultado: " . $stmt->error);
+        logError("Error al obtener el resultado: " . $stmt->error . " - SQL: $sql");
         return null;
     }
 
@@ -115,7 +116,7 @@ if (!function_exists('ejecutarConsulta')) {
         
         // Verifica si la consulta fue exitosa
         if (!$query) {
-            echo "Error en la consulta: " . $conexion->error;
+            logError("Error en la consulta: " . $conexion->error . " - SQL: $sql");
             return false;
         }
         
@@ -133,3 +134,4 @@ if (!function_exists('ejecutarConsulta')) {
 
 }
 ?>
+

--- a/controlador/LoginPostulanteController.php
+++ b/controlador/LoginPostulanteController.php
@@ -3,6 +3,7 @@
 
 require_once "../modelos/Applicant.php";
 require_once "../config/Conexion.php"; // Asegúrate de que la ruta sea correcta
+require_once "../config/Utilidades.php";
 
 class LoginPostulanteController
 {
@@ -68,11 +69,6 @@ if (isset($_GET['op'])) {
             $controller->verificar();
             break;
     }
-}
-
-// Función para registrar errores en el archivo de log
-function logError($message) {
-    file_put_contents('../logs/errors.log', date('[Y-m-d H:i:s] ') . $message . PHP_EOL, FILE_APPEND);
 }
 
 // Asegúrate de que la función limpiarCadena está definida correctamente

--- a/controlador/LoginSupplierController.php
+++ b/controlador/LoginSupplierController.php
@@ -2,6 +2,7 @@
 // Archivo: ../controlador/LoginSupplierController.php
 
 require_once "../config/Conexion.php"; // Incluir Conexion.php
+require_once "../config/Utilidades.php";
 require_once "../modelos/Supplier.php";
 
 class LoginSupplierController
@@ -71,8 +72,4 @@ if (isset($_GET['op'])) {
     }
 }
 
-// Función para registrar errores en el archivo de log
-function logError($message) {
-    file_put_contents('../logs/errors.log', date('[Y-m-d H:i:s] ') . $message . PHP_EOL, FILE_APPEND);
-}
 ?>

--- a/index.php
+++ b/index.php
@@ -9,6 +9,7 @@ require_once 'vendor/autoload.php';
 
 // Incluir archivos de configuración
 require_once 'config/global.php';
+require_once 'config/Utilidades.php';
 
 // Obtener la URL desde el parámetro 'url' o establecer 'home' por defecto
 $url = isset($_GET['url']) ? $_GET['url'] : 'home';
@@ -42,13 +43,16 @@ if (file_exists($controllerPath)) {
             call_user_func_array([$controller, $method], $params);
         } else {
             // Método no encontrado
+            logError('Método no encontrado: ' . $controllerName . '->' . $method);
             echo 'Error 404: Método no encontrado';
         }
     } else {
         // Clase del controlador no encontrada
+        logError('Controlador no encontrado: ' . $controllerName);
         echo 'Error 404: Controlador no encontrado';
     }
 } else {
     // Archivo del controlador no encontrado
+    logError('Archivo del controlador no encontrado: ' . $controllerPath);
     echo 'Error 404: Página no encontrada';
 }


### PR DESCRIPTION
## Summary
- centralize error logging across PHP scripts
- ensure both login controllers use global utilities
- log controller errors from `index.php`

## Testing
- `php -l config/Conexion.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8ffd7254832787b74cfdc838409d