### PR TITLE
Fix duplicate limpiarCadena definition

### DIFF
--- a/config/Conexion.php
+++ b/config/Conexion.php
@@ -124,11 +124,13 @@ if (!function_exists('ejecutarConsulta')) {
         }
     }
 
-    function limpiarCadena($str)
-    {
-        global $conexion;
-        $str = mysqli_real_escape_string($conexion, trim($str));
-        return htmlspecialchars($str);
+    if (!function_exists('limpiarCadena')) {
+        function limpiarCadena($str)
+        {
+            global $conexion;
+            $str = mysqli_real_escape_string($conexion, trim($str));
+            return htmlspecialchars($str);
+        }
     }
 
     function ejecutarConsultaArray($sql, $params = [])


### PR DESCRIPTION
## Summary
- guard limpiarCadena definition in `Conexion.php` to avoid redeclaration error

## Testing
- `composer install` *(fails: composer not found)*
- `php -l config/Conexion.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9b3f5b608327a24cf6afadb7599b