### PR TITLE
Fix AJAX proxy paths for DNI and RUC lookups

### DIFF
--- a/vistas/scripts/applicants.js
+++ b/vistas/scripts/applicants.js
@@ -466,7 +466,7 @@ function cargarPuestosPorArea(areaId, selector, selectedJobId = null) {
 // Función para consultar DNI al agregar
 function consultarDNI(dni) {
     $.ajax({
-        url: 'proxy?dni=' + dni,
+        url: '/documenta/proxy?dni=' + dni,
         method: 'GET',
         dataType: 'json',
         success: function (response) {
@@ -489,7 +489,7 @@ function consultarDNI(dni) {
 // Función para consultar DNI al actualizar
 function consultarDNIUpdate(dni) {
     $.ajax({
-        url: 'proxy?dni=' + dni,
+        url: '/documenta/proxy?dni=' + dni,
         method: 'GET',
         dataType: 'json',
         success: function (response) {

--- a/vistas/scripts/supplier.js
+++ b/vistas/scripts/supplier.js
@@ -68,7 +68,7 @@ function listar() {
 // Función para consultar RUC
 function consultarRUC(ruc) {
     $.ajax({
-        url: 'proxyRUC',
+        url: '/documenta/proxyRUC',
         method: 'GET',
         data: { ruc: ruc },
         success: function (response) {
@@ -106,7 +106,7 @@ function consultarRUC(ruc) {
 // Función para consultar RUC al actualizar
 function consultarRUCUpdate(ruc) {
     $.ajax({
-        url: 'proxyRUC', // Cambia la ruta si es necesario
+        url: '/documenta/proxyRUC', // Cambia la ruta si es necesario
         method: 'GET',
         data: { ruc: ruc },
         success: function (response) {

--- a/vistas/scripts/user.js
+++ b/vistas/scripts/user.js
@@ -509,7 +509,7 @@ function mostrarHistorial(userId) {
 // Function to check DNI when adding a user
 function consultarDNI(dni) {
     $.ajax({
-        url: 'proxy',
+        url: '/documenta/proxy',
         method: 'GET',
         data: { dni: dni },
         dataType: 'json',
@@ -533,7 +533,7 @@ function consultarDNI(dni) {
 // Function to check DNI when updating a user
 function consultarDNIUpdate(dni) {
     $.ajax({
-        url: 'proxy',
+        url: '/documenta/proxy',
         method: 'GET',
         data: { dni: dni },
         dataType: 'json',


### PR DESCRIPTION
## Summary
- fix relative URLs used by `consultarDNI` and `consultarRUC` so they work under htaccess rewrite rules

## Testing
- `grep -R "proxy" vistas/scripts`

------
https://chatgpt.com/codex/tasks/task_e_684f9df68c6483278a2aa0374bb407f4